### PR TITLE
added logic to only show bins based on cookie data

### DIFF
--- a/src/pages/Bin.jsx
+++ b/src/pages/Bin.jsx
@@ -2,9 +2,12 @@ import { useParams } from "react-router-dom";
 import { Link } from "react-router-dom";
 import BinURL from "../components/BinURL";
 import RequestList from "../components/RequestList";
+import { addCookie } from "../services/cookies";
 
 function Bin() {
   const { uuid } = useParams();
+  addCookie(document, uuid);
+
   return (
     <>
       <div className="fixed  h-screen bg-white left-0 shadow-sm border-r-gray-200 w-96">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import BinPreview from "../components/BinPreview";
 import { useEffect, useState } from "react";
 import { getBins, createBin } from "../services/bins";
+import { addCookie, findCookieBins } from "../services/cookies";
 
 // Bug somewhere. Why are not all the bins being rendered.
 // Anything that gets created on that load should be new.
@@ -10,14 +11,17 @@ function Home() {
   useEffect(() => {
     async function allBins() {
       const data = await getBins();
-      setBins(data);
+      const cookieBins = findCookieBins(document, data);
+      setBins(cookieBins);
     }
     allBins();
+
   }, []);
 
   async function create() {
     const data = await createBin();
     data.isNew = true;
+    addCookie(document, data.uuid);
     setBins([data, ...bins]);
   }
 

--- a/src/services/cookies.js
+++ b/src/services/cookies.js
@@ -1,0 +1,12 @@
+function addCookie(documentStore, uuid) {
+  documentStore.cookie += `uuid=${uuid};max-age=360`;
+}
+
+function findCookieBins(documentStore, binData) {
+  const cookieUUIDS = documentStore.cookie.split(/;|uuid=/);
+  return binData.filter(bin => cookieUUIDS.includes(bin.uuid));
+}
+
+export { addCookie, findCookieBins };
+
+


### PR DESCRIPTION
logic/functionality added:
i. add a cookie to store bin uuids after the create new bin button is pressed and if a user navigates to a specific bin url based on its uuid
ii. it filters the all bins list based on bin uuids in the cookie
iii. it sets an expiration date of cookies to 1 hour (somewhat arbitrary we can change this)

How I tested the logic:
1. Hit create bin a couple of times and took note of one of the uuids created
2. Cleared browser history/cookie data. When refreshed localhost:PORT, all bins just created disappeared
3. In search engine, navigated to one of the bins just created in step 1 ( localhost:PORT/<bin_uuid>)
4. In search engine navigated back to localhost:PORT, only the single bin just visited appeared