### PR TITLE
adjusted overflow formatting to keep requests within container and to…

### DIFF
--- a/src/components/RequestDetails.jsx
+++ b/src/components/RequestDetails.jsx
@@ -25,7 +25,7 @@ function RequestDetails({ activeRequest }) {
       </div>
       <div className="mt-6">
         <h2 className="font-bold text-lg mb-2">Headers</h2>
-        <div className="overflow-x-auto ">
+        <div className="max-h-[300px] overflow-x-scroll">
           <table className="w-full">
             {Object.keys(activeRequest.headers).map((key) => (
               <tr className="border-b border-b-gray-300">
@@ -40,7 +40,7 @@ function RequestDetails({ activeRequest }) {
       </div>
       <div className="mt-6">
         <h2 className="font-bold text-lg mb-4">Body</h2>
-        <div className="whitespace-pre bg-gray-200 p-4 rounded overflow-x-scroll">
+        <div className="bg-gray-200 p-4 rounded overflow-y-scroll">
           {activeRequest.body}
         </div>
       </div>

--- a/src/components/RequestDetails.jsx
+++ b/src/components/RequestDetails.jsx
@@ -25,7 +25,7 @@ function RequestDetails({ activeRequest }) {
       </div>
       <div className="mt-6">
         <h2 className="font-bold text-lg mb-2">Headers</h2>
-        <div className="max-h-[300px] overflow-x-scroll">
+        <div className="overflow-x-auto ">
           <table className="w-full">
             {Object.keys(activeRequest.headers).map((key) => (
               <tr className="border-b border-b-gray-300">
@@ -40,7 +40,7 @@ function RequestDetails({ activeRequest }) {
       </div>
       <div className="mt-6">
         <h2 className="font-bold text-lg mb-4">Body</h2>
-        <div className="bg-gray-200 p-4 rounded overflow-y-scroll">
+        <div className="whitespace-pre bg-gray-200 p-4 rounded overflow-x-scroll">
           {activeRequest.body}
         </div>
       </div>

--- a/src/pages/Bin.jsx
+++ b/src/pages/Bin.jsx
@@ -40,7 +40,7 @@ function Bin() {
 
   return (
     <div className="flex">
-      <div className=" h-screen bg-white shadow-sm border-r-gray-200 w-[430px]">
+      <div className=" h-screen bg-white shadow-sm border-r-gray-200 w-[430px] overflow-y-scroll">
         <Link
           to="/"
           className="text-blue-500 hover:text-blue-600 text-md mt-5 mb-4 block ml-4"


### PR DESCRIPTION
… make body easier to read

Previously, if there were a lot of requests in a bin, they would overflow in the list and if the active request had a long body it was hard to read b/c of the limited horizontal scroll view:
![Screen Shot 2023-01-27 at 6 05 26 AM](https://user-images.githubusercontent.com/76174119/215088956-c8815b73-6eb9-4b09-8e41-2c81924c7abe.png)

I adjusted the formatting to  look like the following (the body still has a horizontal scroll so data in the body that's cutoff width-wise in the image below is still visible if you scroll right; I think adding more height to the body makes it easier to read, but the body's presentation could probably still be tweaked)
![Screen Shot 2023-01-27 at 6 38 48 AM](https://user-images.githubusercontent.com/76174119/215089551-e3786ac5-b4ad-4578-a0e4-cde675008c84.png)

